### PR TITLE
Generate Vocabulary, Context, ClassDefinitions

### DIFF
--- a/v1/ClassDefinitions/Identity/Digital.jsonld
+++ b/v1/ClassDefinitions/Identity/Digital.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Digital"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Digital",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Identity",
+        "rdfs:label": {
+            "fi-fi": "Digitaalinen asia",
+            "en-us": "Digital thing"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Digitaaliset asiat, järjestelmät, ohjelmistot ja data",
+            "en-us": "Digital things such as systems, software and data"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Digital/Data.jsonld
+++ b/v1/ClassDefinitions/Identity/Digital/Data.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Digital/Data"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Digital/Data",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Digital",
+        "rdfs:label": {
+            "en-us": "Data",
+            "fi-fi": "Data"
+        },
+        "rdfs:comment": {
+            "en-us": "Any sequence of one or more symbols given meaning by specific act(s) of interpretation",
+            "fi-fi": "Data on tietoa, jolla itsessään ei ole välttämättä semanttista merkitystä tai informatiivista järjestystä"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Digital/DigitalIdentity.jsonld
+++ b/v1/ClassDefinitions/Identity/Digital/DigitalIdentity.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Digital/DigitalIdentity"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Digital/DigitalIdentity",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Digital",
+        "rdfs:label": {
+            "en-us": "Digital identity",
+            "fi-fi": "Digtaalinen identiteetti"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Digitaalinen versio mistä tahansa reaalimaailman entiteetistä tässä ontologiassa",
+            "en-us": "Digital representation of any real world thing in this ontology. Identity as \"set of attributes related to an entity\""
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Digital/Software.jsonld
+++ b/v1/ClassDefinitions/Identity/Digital/Software.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Digital/Software"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Digital/Software",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Digital",
+        "rdfs:label": {
+            "fi-fi": "Ohjelmisto",
+            "en-us": "Software"
+        },
+        "rdfs:comment": {
+            "en-us": "Collection of data or computer instructions that tell the computer how to work from apps, backends to web sites",
+            "fi-fi": "useista tietokoneohjelmista, niiden käyttämistä tiedostoista ja niihin liittyvästä dokumentaatiosta muodostuva kokonaisuus applikaatioista globaaleihin tietojärjestelmiin"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Digital/Software/App.jsonld
+++ b/v1/ClassDefinitions/Identity/Digital/Software/App.jsonld
@@ -1,0 +1,218 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Digital/Software/App"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Digital/Software/App",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Software",
+        "rdfs:label": {
+            "en-us": "Application",
+            "fi-fi": "Sovellus"
+        },
+        "rdfs:comment": {
+            "en-us": "A software application mobile or web",
+            "fi-fi": "Ohjelmisto sovellus"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "description": {
+                "@id": "pot:description",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Description",
+                    "fi-fi": "Kuvaus"
+                },
+                "rdfs:comment": {
+                    "en-us": "Description of an app"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "iconUrl": {
+                "@id": "pot:iconUrl",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Icon URL",
+                    "fi-fi": "Ikonin URL"
+                },
+                "rdfs:comment": {
+                    "en-us": "Icon URL of an app"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "privacyPolicyUrl": {
+                "@id": "pot:privacyPolicyUrl",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Privacy policy URL",
+                    "fi-fi": "Tietousojaselosteen URL"
+                },
+                "rdfs:comment": {
+                    "en-us": "Privacy policy URL of an app"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "webpageUrl": {
+                "@id": "pot:webpageUrl",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Webpage URL",
+                    "fi-fi": "Websivun URL"
+                },
+                "rdfs:comment": {
+                    "en-us": "Webpage URL of an app"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Digital/Software/Platform.jsonld
+++ b/v1/ClassDefinitions/Identity/Digital/Software/Platform.jsonld
@@ -1,0 +1,149 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Digital/Software/Platform"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Digital/Software/Platform",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Software",
+        "rdfs:label": {
+            "en-us": "Platform"
+        },
+        "rdfs:comment": {
+            "en-us": "A data operator platform running on top of LifeEngine",
+            "fi-fi": "Lifeenginen päälle rakennettu data operaattorialusta"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Group.jsonld
+++ b/v1/ClassDefinitions/Identity/Group.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Group"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Group",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Identity",
+        "rdfs:label": {
+            "en-us": "Group of persons or things",
+            "fi-fi": "Ryhmä henkilöitä tai "
+        },
+        "rdfs:comment": {
+            "en-us": "Any group of non-human or juridical persons from nations to adhoc teams",
+            "fi-fi": "Mikä tahansa ryhmä ihmisiä oikeushenkilöistä kuten valtioista aina satunnaisiin kaveriryhmiin"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Group/LegalEntity.jsonld
+++ b/v1/ClassDefinitions/Identity/Group/LegalEntity.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Group/LegalEntity"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Group/LegalEntity",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Group",
+        "rdfs:label": {
+            "en-us": "Legal entity",
+            "fi-fi": "Oikeushenkilö"
+        },
+        "rdfs:comment": {
+            "en-us": "Firm, organization or government agency that is recognized as having privileges and obligations, such as having the ability to enter into contracts, to sue, and to be sued",
+            "fi-fi": "Oikeuskelpoinen taho, joka voi saada oikeuksia ja tulla velvoitetuksi joka on yritys, yhteisö ja julkisoikeudellinen taho"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Group/LegalEntity/ListedCompany.jsonld
+++ b/v1/ClassDefinitions/Identity/Group/LegalEntity/ListedCompany.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Group/LegalEntity/ListedCompany"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Group/LegalEntity/ListedCompany",
+        "@type": "owl:Class",
+        "subClassOf": "pot:LegalEntity",
+        "rdfs:label": {
+            "fi-fi": "Listattu osakeyhtiö",
+            "en-us": "Listed company"
+        },
+        "rdfs:comment": {
+            "en-us": "A private company whose owners are legally responsible for its debts only to the extent of the amount of capital they invested",
+            "fi-fi": "Yritys, jonka osakekanta on yksityisesti omistettu"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Group/LegalEntity/NonListedCompany.jsonld
+++ b/v1/ClassDefinitions/Identity/Group/LegalEntity/NonListedCompany.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Group/LegalEntity/NonListedCompany"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Group/LegalEntity/NonListedCompany",
+        "@type": "owl:Class",
+        "subClassOf": "pot:LegalEntity",
+        "rdfs:label": {
+            "fi-fi": "Listaamaton osakeyhtiö",
+            "en-us": "Non-listed company"
+        },
+        "rdfs:comment": {
+            "en-us": "A company whose shares are traded freely on a stock exchange",
+            "fi-fi": "Julkisesti noteerattu yritys, jonka yhdellä tai useammall osakesarjalla voi käydä kauppaa"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Group/LegalEntity/NonListedCompany/HousingCompany.jsonld
+++ b/v1/ClassDefinitions/Identity/Group/LegalEntity/NonListedCompany/HousingCompany.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Group/LegalEntity/NonListedCompany/HousingCompany"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Group/LegalEntity/NonListedCompany/HousingCompany",
+        "@type": "owl:Class",
+        "subClassOf": "pot:NonListedCompany",
+        "rdfs:label": {
+            "fi-fi": "Asunto-osakeyhtiö",
+            "en-us": "Housing company"
+        },
+        "rdfs:comment": {
+            "en-us": "A legal entity, usually a cooperative or a corporation, which owns real estate, consisting of one or more residential buildings",
+            "fi-fi": "Asunto-osakeyhtiö on osakeyhtiö, jonka yhtiöjärjestyksessä määrätty tarkoitus on omistaa ja hallita vähintään yhtä sellaista rakennusta tai sen osaa, jossa olevan huoneiston tai huoneistojen yhteenlasketusta lattiapinta-alasta yli puolet on yhtiöjärjestyksessä määrätty osakkeenomistajien hallinnassa oleviksi asuinhuoneistoiksi"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Group/NonLegalEntity.jsonld
+++ b/v1/ClassDefinitions/Identity/Group/NonLegalEntity.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Group/NonLegalEntity"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Group/NonLegalEntity",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Group",
+        "rdfs:label": {
+            "fi-fi": "Luonnollinen henkilö",
+            "en-us": "Non legal entity"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Järjestäytymätön ryhmä ihmisiä ilman juridista asemaa ryhmänä",
+            "en-us": "Unorganized group of people without any legal standing as a group"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Person.jsonld
+++ b/v1/ClassDefinitions/Identity/Person.jsonld
@@ -1,0 +1,184 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Person"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Person",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Identity",
+        "rdfs:label": {
+            "en-us": "Human",
+            "fi-fi": "Ihminen"
+        },
+        "rdfs:comment": {
+            "en-us": "A human being, individual",
+            "fi-fi": "Luonnollinen henkilö, yksilö ja yksityinen oikeushenkilö"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "firstName": {
+                "@id": "pot:firstName",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "First name",
+                    "fi-fi": "Sukunimi"
+                },
+                "rdfs:comment": {
+                    "en-us": "First name of a person"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "lastName": {
+                "@id": "pot:lastName",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Etunimi",
+                    "en-us": "Last name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Last name of a person"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Thing.jsonld
+++ b/v1/ClassDefinitions/Identity/Thing.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Thing",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Identity",
+        "rdfs:label": {
+            "fi-fi": "Fyysinen asia",
+            "en-us": "Physical thing"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Eloton luonto ja ihmisen valmistamat esineet ja rakenteet aina kivistä, kaupunkeihin, tuotteisiin, jokiin, autoihin ja käkikelloihin",
+            "en-us": "Things in inanimate physical world from products, rocks, cities, rivers to cars and space ships"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Thing/HumanWorld.jsonld
+++ b/v1/ClassDefinitions/Identity/Thing/HumanWorld.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Thing/HumanWorld",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Thing",
+        "rdfs:label": {
+            "en-us": "Human made world",
+            "fi-fi": "Ihmisen tekemä maailma"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Luonnon muodostama ympäristö geologiasta, vedestä luonnon resusseihin ja ilmastoon - planeetta itse",
+            "en-us": "Nature made things from geology to water, natural resources and climate - the planet"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Thing/HumanWorld/Product.jsonld
+++ b/v1/ClassDefinitions/Identity/Thing/HumanWorld/Product.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/Product"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Thing/HumanWorld/Product",
+        "@type": "owl:Class",
+        "subClassOf": "pot:HumanWorld",
+        "rdfs:label": {
+            "en-us": "Product",
+            "fi-fi": "Tuote"
+        },
+        "rdfs:comment": {
+            "en-us": "Any human made physical product from socks to dishwashers and jumbojets",
+            "fi-fi": "Kaikki valmistetut fyysiset tuotteet sukista tiskikoneisiin ja jumbojetteihin"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Thing/HumanWorld/Product/DataProduct.jsonld
+++ b/v1/ClassDefinitions/Identity/Thing/HumanWorld/Product/DataProduct.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/Product/DataProduct"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Thing/HumanWorld/Product/DataProduct",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Product",
+        "rdfs:label": {
+            "en-us": "Data Product",
+            "fi-fi": "Tietotuote"
+        },
+        "rdfs:comment": {
+            "en-us": "A Lifeengine semantic data product capable of productizing any data set used in the network and on the platform market places.",
+            "fi-fi": "Lifeenginen semanttisesti määritetty tietotuote joka mahdollistaa minkä tahansa tietueen tuotteistamisen koneluettavaksi paketiksi verkossa ja alustojen kauppapaikoilla"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Thing/HumanWorld/System.jsonld
+++ b/v1/ClassDefinitions/Identity/Thing/HumanWorld/System.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/System"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Thing/HumanWorld/System",
+        "@type": "owl:Class",
+        "subClassOf": "pot:HumanWorld",
+        "rdfs:label": {
+            "fi-fi": "Järjestelmä",
+            "en-us": "System"
+        },
+        "rdfs:comment": {
+            "en-us": "Any physical system built with components from national grid to sewage lines and art installations",
+            "fi-fi": "Fyysinen järjestelmä joka koostuu useammasta komponentista runkoverkoista, talon viemäriin tai taideinstallaatioon"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Thing/HumanWorld/System/BuiltEnvironment.jsonld
+++ b/v1/ClassDefinitions/Identity/Thing/HumanWorld/System/BuiltEnvironment.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Thing/HumanWorld/System/BuiltEnvironment",
+        "@type": "owl:Class",
+        "subClassOf": "pot:System",
+        "rdfs:label": {
+            "en-us": "Built environment",
+            "fi-fi": "Rakennettuympäristö"
+        },
+        "rdfs:comment": {
+            "en-us": "Human-made surroundings that provide the setting for human activity  from buildings, roads, electric lines to parks",
+            "fi-fi": "Ihmisen tekemä ympäristö joka palvelee ihmisen toimintaa ja elämistä aina rakennuksista, teihin, sähkölinjoihin ja puistoihin."
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Thing/HumanWorld/System/BuiltEnvironment/Building.jsonld
+++ b/v1/ClassDefinitions/Identity/Thing/HumanWorld/System/BuiltEnvironment/Building.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment/Building"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Thing/HumanWorld/System/BuiltEnvironment/Building",
+        "@type": "owl:Class",
+        "subClassOf": "pot:BuiltEnvironment",
+        "rdfs:label": {
+            "en-us": "Building",
+            "fi-fi": "Rakennus"
+        },
+        "rdfs:comment": {
+            "en-us": "A building, or edifice, is a structure with a roof and walls standing more or less permanently in one place, such as a house or factory",
+            "fi-fi": "Rakennus on erillinen, kiinteä, omalla sisäänkäynnillä varustettu rakennelma, joka sisältää katettua, yleensä seinien erottamaa tilaa."
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Thing/HumanWorld/System/BuiltEnvironment/Infrastructure.jsonld
+++ b/v1/ClassDefinitions/Identity/Thing/HumanWorld/System/BuiltEnvironment/Infrastructure.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment/Infrastructure"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Thing/HumanWorld/System/BuiltEnvironment/Infrastructure",
+        "@type": "owl:Class",
+        "subClassOf": "pot:BuiltEnvironment",
+        "rdfs:label": {
+            "en-us": "Infrastructure",
+            "fi-fi": "Infrastruktuuri"
+        },
+        "rdfs:comment": {
+            "en-us": "Systems serving a country, city, or other area, including the services and facilities necessary for its economy to function.",
+            "fi-fi": "Yhteiskunnan infrastruktuuri (perusrakenteet ja varusrakenne) muodostuu niistä palveluista ja rakenteista, jotka mahdollistavat yhteiskunnan toiminnan. "
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Thing/HumanWorld/System/BuiltEnvironment/Structure.jsonld
+++ b/v1/ClassDefinitions/Identity/Thing/HumanWorld/System/BuiltEnvironment/Structure.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment/Structure"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Thing/HumanWorld/System/BuiltEnvironment/Structure",
+        "@type": "owl:Class",
+        "subClassOf": "pot:BuiltEnvironment",
+        "rdfs:label": {
+            "en-us": "Non-building structure",
+            "fi-fi": "Rakennelma"
+        },
+        "rdfs:comment": {
+            "en-us": "Any body or system of connected parts used to support a load that was not designed for continuous human occupancy",
+            "fi-fi": "Yleensä yksinkertainen ja kevytrakenteinen rakenne jolle on tyypillistä vähäisyys rakennukseen verrattuna ja usein myös väliaikaisuus, mutta rakennelma saattaa olla myös hyvin suuri ja pysyvä, esimerkiksi pato tai radiomasto"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Thing/NaturalWorld.jsonld
+++ b/v1/ClassDefinitions/Identity/Thing/NaturalWorld.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/NaturalWorld"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Thing/NaturalWorld",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Thing",
+        "rdfs:label": {
+            "fi-fi": "Eloton luonto",
+            "en-us": "Non-living nature"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Luonnon muodostama ympäristö geologiasta, vedestä luonnon resusseihin ja ilmastoon - planeetta itse",
+            "en-us": "Nature made things from geology to water, natural resources and climate - the planet"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Thing/NaturalWorld/Land.jsonld
+++ b/v1/ClassDefinitions/Identity/Thing/NaturalWorld/Land.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/NaturalWorld/Land"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Thing/NaturalWorld/Land",
+        "@type": "owl:Class",
+        "subClassOf": "pot:NaturalWorld",
+        "rdfs:label": {
+            "en-us": "Land",
+            "fi-fi": "Maa-alue"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Kiinteä maanpinta joka ei pysyvästi ole veden peitossa.",
+            "en-us": "Solid surface of Earth that is not permanently covered by water"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Thing/NaturalWorld/Water.jsonld
+++ b/v1/ClassDefinitions/Identity/Thing/NaturalWorld/Water.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/NaturalWorld/Water"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Thing/NaturalWorld/Water",
+        "@type": "owl:Class",
+        "subClassOf": "pot:NaturalWorld",
+        "rdfs:label": {
+            "fi-fi": "Vesialue",
+            "en-us": "Water"
+        },
+        "rdfs:comment": {
+            "en-us": "Areas of Earth that are permanently covered by water from puddles to oceans",
+            "fi-fi": "Pysyvästi ole veden peitossa olevat alueet maapalolla lammikoista valtameriin."
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Identity",
+        "rdfs:label": {
+            "fi-fi": "Virtuaalinen asia",
+            "en-us": "Virtual thing"
+        },
+        "rdfs:comment": {
+            "en-us": "Abstract things from contracts to spaces and processes",
+            "fi-fi": "Abstraktit asiat aina sopimuksista, dokumentteihin, tiloihin ja prosesseihin"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual/Asset.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual/Asset.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Asset"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual/Asset",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Virtual",
+        "rdfs:label": {
+            "en-us": "Asset",
+            "fi-fi": "Varallisuuserä"
+        },
+        "rdfs:comment": {
+            "en-us": "Fixed or movable assets, real or immaterial property",
+            "fi-fi": "Kiinteä tai irtain omaisuus, reaali- tai immateriaaliomaisuus"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual/Collection.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual/Collection.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Collection"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual/Collection",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Virtual",
+        "rdfs:label": {
+            "en-us": "Collection of anything",
+            "fi-fi": "Joukko asioita"
+        },
+        "rdfs:comment": {
+            "en-us": "Collection forms a group, collection, inventory or a set of any other classes",
+            "fi-fi": "Ryhmä, kataloogi, inventaario tai kokoelma mitä tahansa muita luokkia"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual/Collection/Vocabulary.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual/Collection/Vocabulary.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Collection/Vocabulary"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual/Collection/Vocabulary",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Collection",
+        "rdfs:label": {
+            "fi-fi": "Sanasto",
+            "en-us": "Vocabulary"
+        },
+        "rdfs:comment": {
+            "en-us": "A vocabulary defines the supported classes, supported attributes for a class and supported types for a class. The vocabulary also defines any mandatory attributes and anything that is programmatically needed to manipulate identities",
+            "fi-fi": "Sanasto määrittelee tuetut luokat, tuetut attribuutit sekä tuetut tyypit luokille. Sanasto myös kuvaa pakollisia kenttiä, sekä kaiken mitä tarvitaan ohjelmallisesti identiteettien hallintaan"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual/Contract.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual/Contract.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Contract"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual/Contract",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Virtual",
+        "rdfs:label": {
+            "en-us": "Contract",
+            "fi-fi": "Sopimus"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Kahden tai useamman tahon välinen toimi, jolla luodaan tai muutetaan velvoitteita lakisääteisesti",
+            "en-us": "Legally-binding agreement which recognises and governs the rights and duties of the parties to the agreement"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual/Document.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual/Document.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Document"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual/Document",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Virtual",
+        "rdfs:label": {
+            "en-us": "Document",
+            "fi-fi": "Dokumentti"
+        },
+        "rdfs:comment": {
+            "en-us": "A document is a written, drawn, presented, or memorialized representation of thought. It can be in paper or electronic format.",
+            "fi-fi": "Asiakirja, asiapaperi, kirjallinen todistuskappale tai todiste. Dokumentti voi olla esimerkiksi paperinen tai sähköinen"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual/Event.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual/Event.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Event"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual/Event",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Virtual",
+        "rdfs:label": {
+            "en-us": "Event",
+            "fi-fi": "Tapahtuma"
+        },
+        "rdfs:comment": {
+            "en-us": "A point in space at an instant in time, meeting, ceremony, happening, festival, sporting event, task, party or such.",
+            "fi-fi": "Mikä hyvänsä tietyssä paikassa tiettynä hetkenä esiintyvä ilmiö, ainutkertainen tai toistuva, kokous, tehtävä, seremonia, juhla tai muu vastaava tapahtuma"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual/Event/Task.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual/Event/Task.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Event/Task"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual/Event/Task",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Event",
+        "rdfs:label": {
+            "en-us": "Task",
+            "fi-fi": "Tehtävä"
+        },
+        "rdfs:comment": {
+            "en-us": "An activity that needs to be accomplished within a defined period of time or by a deaowlne",
+            "fi-fi": "Toimi joka on saatava päätökseen asetetussa aikataulussa tai tiettyyn ajankohtaan mennessä"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual/Liability.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual/Liability.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Liability"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual/Liability",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Virtual",
+        "rdfs:label": {
+            "en-us": "Liability",
+            "fi-fi": "Vastuu"
+        },
+        "rdfs:comment": {
+            "en-us": "Financial accounting or legal liability ",
+            "fi-fi": "Kirjanpidollinen tai lakimääräinen vastuu"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual/Process.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual/Process.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Process"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual/Process",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Virtual",
+        "rdfs:label": {
+            "en-us": "Project",
+            "fi-fi": "Projekti"
+        },
+        "rdfs:comment": {
+            "en-us": "A process is a set of activities that interact to produce a result from business, engineering to legal and scientific processes",
+            "fi-fi": "Yleisesti prosessi sarja edistymistä tai toimenpiteitä aina kemiallisista, oikeudenkäynnin ja liiketoiminnan prosesseihin"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual/Process/Project.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual/Process/Project.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Process/Project"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual/Process/Project",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Process",
+        "rdfs:label": {
+            "en-us": "Project",
+            "fi-fi": "Projekti"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Sarja tehtäviä joilla on selvä lopputulema ja aikajänne yrityksen kehitysprojekteista metron rakentamiseen.",
+            "en-us": "Set of tasks with an aim and timeframe from business projects to building a metro line"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual/Process/Transaction.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual/Process/Transaction.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Process/Transaction"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual/Process/Transaction",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Process",
+        "rdfs:label": {
+            "en-us": "Transaction",
+            "fi-fi": "Transaktio"
+        },
+        "rdfs:comment": {
+            "en-us": "Interaction between two parties e.g. financial payment, deal, settlement, database write or trade of goods",
+            "fi-fi": "Yksittäinen osapuolien välinen tapahtuma taloustieteessä, kaupassa, rahoituksessa tai esim. tietokantaan tehtävä kirjoitustapahtuma"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Virtual/Restriction.jsonld
+++ b/v1/ClassDefinitions/Identity/Virtual/Restriction.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Restriction"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Virtual/Restriction",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Virtual",
+        "rdfs:label": {
+            "fi-fi": "Rajoitus",
+            "en-us": "Restriction"
+        },
+        "rdfs:comment": {
+            "en-us": "Financial accounting or legal restriction e.g. a pledge or guardian ship ",
+            "fi-fi": "Kirjanpidollinen tai lakimääräinen rajoitus kuten pantti tai edunvalvonta"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Wilowlfe.jsonld
+++ b/v1/ClassDefinitions/Identity/Wilowlfe.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Wilowlfe"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Wilowlfe",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Identity",
+        "rdfs:label": {
+            "fi-fi": "Kasvit ja eläimet",
+            "en-us": "Wilowlfe"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Elävä luonto ihmistä lukuunottamatta. Eläimet ja kasvit",
+            "en-us": "Living nature apart from humans. Flora and fauna"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Wilowlfe/Fauna.jsonld
+++ b/v1/ClassDefinitions/Identity/Wilowlfe/Fauna.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Wilowlfe/Fauna"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Wilowlfe/Fauna",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Wilowlfe",
+        "rdfs:label": {
+            "fi-fi": "Eläimet",
+            "en-us": "Fauna"
+        },
+        "rdfs:comment": {
+            "en-us": "Animal life from plankton to mammals and dinosaurs",
+            "fi-fi": "Eläimistö, systemaattinen esitys jonkin alueen eläinlajeista nilviäisistä, nisäkkäisiin ja dinosauruksiin."
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Identity/Wilowlfe/Flora.jsonld
+++ b/v1/ClassDefinitions/Identity/Wilowlfe/Flora.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Wilowlfe/Flora"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Identity/Wilowlfe/Flora",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Wilowlfe",
+        "rdfs:label": {
+            "en-us": "Flora",
+            "fi-fi": "Kasvit"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Kasveista koostuva elämä, kasvilajisto kukkasista, puihin ja metsiin.",
+            "en-us": "Naturally occurring or indigenous native plant life from flowers, trees to forests."
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "name": {
+                "@id": "pot:name",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Nimi",
+                    "en-us": "Name"
+                },
+                "rdfs:comment": {
+                    "en-us": "Name of the data product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Link/AtDataProduct.jsonld
+++ b/v1/ClassDefinitions/Link/AtDataProduct.jsonld
@@ -1,0 +1,167 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/AtDataProduct"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Link/AtDataProduct",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Link",
+        "rdfs:label": {
+            "en-us": "Data Product",
+            "fi-fi": "Tietotuote"
+        },
+        "rdfs:comment": {
+            "en-us": "Data product that is related to a real world identity",
+            "fi-fi": "Tietotuote, joka liittyy johonkin reaalimaailman asiaan"
+        },
+        "pot:supportedAttribute": {
+            "contentId": {
+                "@id": "pot:contentId",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Content ID",
+                    "fi-fi": "Sisällön ID"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data content Id"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedAt": {
+                "@id": "pot:updatedAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Päivitysaika",
+                    "en-us": "Update time"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is updated"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Link/PublishedOn.jsonld
+++ b/v1/ClassDefinitions/Link/PublishedOn.jsonld
@@ -1,0 +1,167 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/PublishedOn"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Link/PublishedOn",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Link",
+        "rdfs:label": {
+            "fi-fi": "Julkaistu",
+            "en-us": "Published"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Osoittaa linkin jossa digitaalinen asia on julkaistu",
+            "en-us": "Shows the link in which a digital thing is published"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "productCode": {
+                "@id": "pot:productCode",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Product code",
+                    "fi-fi": "Tuotekoodi"
+                },
+                "rdfs:comment": {
+                    "en-us": "Unique identifier of a product"
+                },
+                "pot:required": false,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedAt": {
+                "@id": "pot:updatedAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Päivitysaika",
+                    "en-us": "Update time"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is updated"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Link/Role.jsonld
+++ b/v1/ClassDefinitions/Link/Role.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/Role"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Link/Role",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Link",
+        "rdfs:label": {
+            "en-us": "Role",
+            "fi-fi": "Rooli"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Henkilön rooli suhteessa identiteettiin",
+            "en-us": "Person's role to an identity"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedAt": {
+                "@id": "pot:updatedAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Päivitysaika",
+                    "en-us": "Update time"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is updated"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Link/Role/DeveloperAt.jsonld
+++ b/v1/ClassDefinitions/Link/Role/DeveloperAt.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/Role/DeveloperAt"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Link/Role/DeveloperAt",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Role",
+        "rdfs:label": {
+            "en-us": "Developer",
+            "fi-fi": "Kehittäjä"
+        },
+        "rdfs:comment": {
+            "en-us": "Developer at a platform",
+            "fi-fi": "Kehittäjä joka kehittää sovelluksia tai tietotuotteita alustalla"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedAt": {
+                "@id": "pot:updatedAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Päivitysaika",
+                    "en-us": "Update time"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is updated"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Link/Role/DeveloperOf.jsonld
+++ b/v1/ClassDefinitions/Link/Role/DeveloperOf.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/Role/DeveloperOf"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Link/Role/DeveloperOf",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Role",
+        "rdfs:label": {
+            "en-us": "Developer",
+            "fi-fi": "Kehittäjä"
+        },
+        "rdfs:comment": {
+            "en-us": "Developer who is a member of a developer organization",
+            "fi-fi": "Johonkin oraganisaatioon kuuluva kehittäjä"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedAt": {
+                "@id": "pot:updatedAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Päivitysaika",
+                    "en-us": "Update time"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is updated"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Link/Role/MemberOf.jsonld
+++ b/v1/ClassDefinitions/Link/Role/MemberOf.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/Role/MemberOf"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Link/Role/MemberOf",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Role",
+        "rdfs:label": {
+            "fi-fi": "Jäsen",
+            "en-us": "Member"
+        },
+        "rdfs:comment": {
+            "en-us": "Member of a group",
+            "fi-fi": "Ryhmän jäsen"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedAt": {
+                "@id": "pot:updatedAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Päivitysaika",
+                    "en-us": "Update time"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is updated"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/ClassDefinitions/Link/Role/UserOf.jsonld
+++ b/v1/ClassDefinitions/Link/Role/UserOf.jsonld
@@ -1,0 +1,150 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": {
+            "@id": "http://www.w3.org/2001/XMLSchema#",
+            "@prefix": true
+        },
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "description": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "label": {
+            "@id": "rdfs:label",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "comment": {
+            "@id": "rdfs:comment",
+            "@container": [
+                "@language",
+                "@set"
+            ]
+        },
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/Role/UserOf"
+    },
+    "pot:supportedClass": {
+        "@id": "pot:Link/Role/UserOf",
+        "@type": "owl:Class",
+        "subClassOf": "pot:Role",
+        "rdfs:label": {
+            "fi-fi": "Käyttäjä",
+            "en-us": "User"
+        },
+        "rdfs:comment": {
+            "fi-fi": "Digitaalisen asian käyttäjä",
+            "en-us": "User of a digital thing"
+        },
+        "pot:supportedAttribute": {
+            "createdAt": {
+                "@id": "pot:createdAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creation time",
+                    "fi-fi": "Luomisaika"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is created"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "createdBy": {
+                "@id": "pot:createdBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Creator",
+                    "fi-fi": "Identiteetin luoja"
+                },
+                "rdfs:comment": {
+                    "en-us": "Creator of and identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "data": {
+                "@id": "pot:data",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Data"
+                },
+                "rdfs:comment": {
+                    "en-us": "Data container"
+                },
+                "pot:required": true,
+                "pot:readonly": false,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "metadata": {
+                "@id": "pot:metadata",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "en-us": "Metadata"
+                },
+                "rdfs:comment": {
+                    "en-us": "Metadata container"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            },
+            "updatedAt": {
+                "@id": "pot:updatedAt",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Päivitysaika",
+                    "en-us": "Update time"
+                },
+                "rdfs:comment": {
+                    "en-us": "Time when the data is updated"
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:dateTime"
+                ]
+            },
+            "updatedBy": {
+                "@id": "pot:updatedBy",
+                "@type": "owl:DatatypeProperty",
+                "subPropertyOf": "pot:topDataProperty",
+                "rdfs:label": {
+                    "fi-fi": "Identieetin päivittäjä",
+                    "en-us": "Updater"
+                },
+                "rdfs:comment": {
+                    "en-us": "Updater of an identity "
+                },
+                "pot:required": false,
+                "pot:readonly": true,
+                "pot:valueType": [
+                    "xsd:string"
+                ]
+            }
+        }
+    }
+}

--- a/v1/Context/Identity/Digital.jsonld
+++ b/v1/Context/Identity/Digital.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Digital",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Digital",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Digital/Data.jsonld
+++ b/v1/Context/Identity/Digital/Data.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Digital/Data",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Digital/Data",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Digital/DigitalIdentity.jsonld
+++ b/v1/Context/Identity/Digital/DigitalIdentity.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Digital/DigitalIdentity",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Digital/DigitalIdentity",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Digital/Software.jsonld
+++ b/v1/Context/Identity/Digital/Software.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Digital/Software",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Digital/Software",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Digital/Software/App.jsonld
+++ b/v1/Context/Identity/Digital/Software/App.jsonld
@@ -1,0 +1,50 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Digital/Software/App",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Digital/Software/App",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "description": {
+            "@id": "pot:description",
+            "@nest": "data"
+        },
+        "iconUrl": {
+            "@id": "pot:iconUrl",
+            "@nest": "data"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "privacyPolicyUrl": {
+            "@id": "pot:privacyPolicyUrl",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "webpageUrl": {
+            "@id": "pot:webpageUrl",
+            "@nest": "data"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Digital/Software/Platform.jsonld
+++ b/v1/Context/Identity/Digital/Software/Platform.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Digital/Software/Platform",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Digital/Software/Platform",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Group.jsonld
+++ b/v1/Context/Identity/Group.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Group",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Group",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Group/LegalEntity.jsonld
+++ b/v1/Context/Identity/Group/LegalEntity.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Group/LegalEntity",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Group/LegalEntity",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Group/LegalEntity/ListedCompany.jsonld
+++ b/v1/Context/Identity/Group/LegalEntity/ListedCompany.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Group/LegalEntity/ListedCompany",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Group/LegalEntity/ListedCompany",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Group/LegalEntity/NonListedCompany.jsonld
+++ b/v1/Context/Identity/Group/LegalEntity/NonListedCompany.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Group/LegalEntity/NonListedCompany",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Group/LegalEntity/NonListedCompany",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Group/LegalEntity/NonListedCompany/HousingCompany.jsonld
+++ b/v1/Context/Identity/Group/LegalEntity/NonListedCompany/HousingCompany.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Group/LegalEntity/NonListedCompany/HousingCompany",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Group/LegalEntity/NonListedCompany/HousingCompany",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Group/NonLegalEntity.jsonld
+++ b/v1/Context/Identity/Group/NonLegalEntity.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Group/NonLegalEntity",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Group/NonLegalEntity",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Person.jsonld
+++ b/v1/Context/Identity/Person.jsonld
@@ -1,0 +1,42 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Person",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Person",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "lastName": {
+            "@id": "pot:lastName",
+            "@nest": "data"
+        },
+        "firstName": {
+            "@id": "pot:firstName",
+            "@nest": "data"
+        }
+    }
+}

--- a/v1/Context/Identity/Thing.jsonld
+++ b/v1/Context/Identity/Thing.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Thing",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Thing/HumanWorld.jsonld
+++ b/v1/Context/Identity/Thing/HumanWorld.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Thing/HumanWorld",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Thing/HumanWorld/Product.jsonld
+++ b/v1/Context/Identity/Thing/HumanWorld/Product.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/Product",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Thing/HumanWorld/Product",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Thing/HumanWorld/Product/DataProduct.jsonld
+++ b/v1/Context/Identity/Thing/HumanWorld/Product/DataProduct.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/Product/DataProduct",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Thing/HumanWorld/Product/DataProduct",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Thing/HumanWorld/System.jsonld
+++ b/v1/Context/Identity/Thing/HumanWorld/System.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/System",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Thing/HumanWorld/System",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Thing/HumanWorld/System/BuiltEnvironment.jsonld
+++ b/v1/Context/Identity/Thing/HumanWorld/System/BuiltEnvironment.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Thing/HumanWorld/System/BuiltEnvironment",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Thing/HumanWorld/System/BuiltEnvironment/Building.jsonld
+++ b/v1/Context/Identity/Thing/HumanWorld/System/BuiltEnvironment/Building.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment/Building",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Thing/HumanWorld/System/BuiltEnvironment/Building",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Thing/HumanWorld/System/BuiltEnvironment/Infrastructure.jsonld
+++ b/v1/Context/Identity/Thing/HumanWorld/System/BuiltEnvironment/Infrastructure.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment/Infrastructure",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Thing/HumanWorld/System/BuiltEnvironment/Infrastructure",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Thing/HumanWorld/System/BuiltEnvironment/Structure.jsonld
+++ b/v1/Context/Identity/Thing/HumanWorld/System/BuiltEnvironment/Structure.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment/Structure",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Thing/HumanWorld/System/BuiltEnvironment/Structure",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Thing/NaturalWorld.jsonld
+++ b/v1/Context/Identity/Thing/NaturalWorld.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/NaturalWorld",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Thing/NaturalWorld",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Thing/NaturalWorld/Land.jsonld
+++ b/v1/Context/Identity/Thing/NaturalWorld/Land.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/NaturalWorld/Land",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Thing/NaturalWorld/Land",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Thing/NaturalWorld/Water.jsonld
+++ b/v1/Context/Identity/Thing/NaturalWorld/Water.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Thing/NaturalWorld/Water",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Thing/NaturalWorld/Water",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual.jsonld
+++ b/v1/Context/Identity/Virtual.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual/Asset.jsonld
+++ b/v1/Context/Identity/Virtual/Asset.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Asset",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual/Asset",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual/Collection.jsonld
+++ b/v1/Context/Identity/Virtual/Collection.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Collection",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual/Collection",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual/Collection/Vocabulary.jsonld
+++ b/v1/Context/Identity/Virtual/Collection/Vocabulary.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Collection/Vocabulary",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual/Collection/Vocabulary",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual/Contract.jsonld
+++ b/v1/Context/Identity/Virtual/Contract.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Contract",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual/Contract",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual/Document.jsonld
+++ b/v1/Context/Identity/Virtual/Document.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Document",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual/Document",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual/Event.jsonld
+++ b/v1/Context/Identity/Virtual/Event.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Event",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual/Event",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual/Event/Task.jsonld
+++ b/v1/Context/Identity/Virtual/Event/Task.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Event/Task",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual/Event/Task",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual/Liability.jsonld
+++ b/v1/Context/Identity/Virtual/Liability.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Liability",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual/Liability",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual/Process.jsonld
+++ b/v1/Context/Identity/Virtual/Process.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Process",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual/Process",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual/Process/Project.jsonld
+++ b/v1/Context/Identity/Virtual/Process/Project.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Process/Project",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual/Process/Project",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual/Process/Transaction.jsonld
+++ b/v1/Context/Identity/Virtual/Process/Transaction.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Process/Transaction",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual/Process/Transaction",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Virtual/Restriction.jsonld
+++ b/v1/Context/Identity/Virtual/Restriction.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Virtual/Restriction",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Virtual/Restriction",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Wilowlfe.jsonld
+++ b/v1/Context/Identity/Wilowlfe.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Wilowlfe",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Wilowlfe",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Wilowlfe/Fauna.jsonld
+++ b/v1/Context/Identity/Wilowlfe/Fauna.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Wilowlfe/Fauna",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Wilowlfe/Fauna",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Identity/Wilowlfe/Flora.jsonld
+++ b/v1/Context/Identity/Wilowlfe/Flora.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Identity/Wilowlfe/Flora",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Identity/Wilowlfe/Flora",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "name": {
+            "@id": "pot:name",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Link/AtDataProduct.jsonld
+++ b/v1/Context/Link/AtDataProduct.jsonld
@@ -1,0 +1,38 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/AtDataProduct",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Link/AtDataProduct",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "updatedAt": {
+            "@id": "pot:updatedAt",
+            "@nest": "metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        },
+        "contentId": {
+            "@id": "pot:contentId",
+            "@nest": "data"
+        }
+    }
+}

--- a/v1/Context/Link/PublishedOn.jsonld
+++ b/v1/Context/Link/PublishedOn.jsonld
@@ -1,0 +1,38 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/PublishedOn",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Link/PublishedOn",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "updatedAt": {
+            "@id": "pot:updatedAt",
+            "@nest": "metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "productCode": {
+            "@id": "pot:productCode",
+            "@nest": "data"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Link/Role.jsonld
+++ b/v1/Context/Link/Role.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/Role",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Link/Role",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        },
+        "updatedAt": {
+            "@id": "pot:updatedAt",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Link/Role/DeveloperAt.jsonld
+++ b/v1/Context/Link/Role/DeveloperAt.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/Role/DeveloperAt",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Link/Role/DeveloperAt",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        },
+        "updatedAt": {
+            "@id": "pot:updatedAt",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Link/Role/DeveloperOf.jsonld
+++ b/v1/Context/Link/Role/DeveloperOf.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/Role/DeveloperOf",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Link/Role/DeveloperOf",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        },
+        "updatedAt": {
+            "@id": "pot:updatedAt",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Link/Role/MemberOf.jsonld
+++ b/v1/Context/Link/Role/MemberOf.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/Role/MemberOf",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Link/Role/MemberOf",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        },
+        "updatedAt": {
+            "@id": "pot:updatedAt",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Context/Link/Role/UserOf.jsonld
+++ b/v1/Context/Link/Role/UserOf.jsonld
@@ -1,0 +1,34 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "@vocab": "https://standards-ontotest.lifeengine.io/Vocabulary/Link/Role/UserOf",
+        "@classDefinition": "https://standards-ontotest.lifeengine.io/ClassDefinitions/Link/Role/UserOf",
+        "pot": {
+            "@id": "https://standards-ontotest.lifeengine.io/Vocabulary/",
+            "@prefix": true
+        },
+        "data": {
+            "@id": "pot:data",
+            "@nest": "data"
+        },
+        "metadata": {
+            "@id": "pot:metadata"
+        },
+        "createdBy": {
+            "@id": "pot:createdBy",
+            "@nest": "metadata"
+        },
+        "createdAt": {
+            "@id": "pot:createdAt",
+            "@nest": "metadata"
+        },
+        "updatedBy": {
+            "@id": "pot:updatedBy",
+            "@nest": "metadata"
+        },
+        "updatedAt": {
+            "@id": "pot:updatedAt",
+            "@nest": "metadata"
+        }
+    }
+}

--- a/v1/Ontology/dli.owl
+++ b/v1/Ontology/dli.owl
@@ -259,7 +259,7 @@
         <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DRAFT</owl:versionInfo>
         <ns1:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</ns1:term_status>
         <nest rdf:resource="https://standards.lifeengine.io/v1/Vocabulary/metadata"/>
-        <nest rdf:resource="https://standards.oftrust.net/v1/Vocabulary/data"/>
+        <nest rdf:resource="https://standards.lifeengine.io/v1/Vocabulary/data"/>
         <readonly rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</readonly>
         <required rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</required>
     </owl:DatatypeProperty>
@@ -278,7 +278,7 @@
         <rdfs:label xml:lang="en-us">Data</rdfs:label>
         <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DRAFT</owl:versionInfo>
         <ns1:term_status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unstable</ns1:term_status>
-        <nest rdf:resource="https://standards.oftrust.net/v1/Vocabulary/data"/>
+        <nest rdf:resource="https://standards.lifeengine.io/v1/Vocabulary/data"/>
         <readonly rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</readonly>
         <required rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</required>
     </owl:DatatypeProperty>

--- a/v1/Vocabulary/Identity.jsonld
+++ b/v1/Vocabulary/Identity.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -76,86 +153,17 @@
             "pot:Link"
         ]
     },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
     "Identity": {
         "@id": "pot:Identity",
-        "@type": "owl:Class"
+        "@type": "owl:Class",
+        "rdfs:label": {
+            "fi-fi": "Digital Living Identiteetti",
+            "en-us": "Digital Living Identity"
+        },
+        "rdfs:comment": {
+            "en-us": "Digital Living core identities",
+            "fi-fi": "Digital Livingin Identiteetti"
+        }
     },
     "Person": {
         "rdfs:subClassOf": {

--- a/v1/Vocabulary/Identity/Digital.jsonld
+++ b/v1/Vocabulary/Identity/Digital.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Digital/Data.jsonld
+++ b/v1/Vocabulary/Identity/Digital/Data.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Digital/DigitalIdentity.jsonld
+++ b/v1/Vocabulary/Identity/Digital/DigitalIdentity.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Digital/Software.jsonld
+++ b/v1/Vocabulary/Identity/Digital/Software.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Digital/Software/App.jsonld
+++ b/v1/Vocabulary/Identity/Digital/Software/App.jsonld
@@ -44,8 +44,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Kuvaus",
-            "en-us": "Description"
+            "en-us": "Description",
+            "fi-fi": "Kuvaus"
         },
         "rdfs:comment": {
             "en-us": "Description of an app"
@@ -57,16 +57,129 @@
             "pot:App"
         ]
     },
+    "iconUrl": {
+        "@id": "pot:iconUrl",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Icon URL",
+            "fi-fi": "Ikonin URL"
+        },
+        "rdfs:comment": {
+            "en-us": "Icon URL of an app"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:App"
+        ]
+    },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "privacyPolicyUrl": {
         "@id": "pot:privacyPolicyUrl",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Tietousojaselosteen URL",
-            "en-us": "Privacy policy URL"
+            "en-us": "Privacy policy URL",
+            "fi-fi": "Tietousojaselosteen URL"
         },
         "rdfs:comment": {
             "en-us": "Privacy policy URL of an app"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:App"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "webpageUrl": {
+        "@id": "pot:webpageUrl",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Webpage URL",
+            "fi-fi": "Websivun URL"
+        },
+        "rdfs:comment": {
+            "en-us": "Webpage URL of an app"
         },
         "pot:valueType": [
             "xsd:string"
@@ -80,8 +193,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -110,119 +223,6 @@
         "domain": [
             "pot:Identity",
             "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "iconUrl": {
-        "@id": "pot:iconUrl",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Icon URL",
-            "fi-fi": "Ikonin URL"
-        },
-        "rdfs:comment": {
-            "en-us": "Icon URL of an app"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App"
-        ]
-    },
-    "webpageUrl": {
-        "@id": "pot:webpageUrl",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Websivun URL",
-            "en-us": "Webpage URL"
-        },
-        "rdfs:comment": {
-            "en-us": "Webpage URL of an app"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App"
         ]
     },
     "App": {

--- a/v1/Vocabulary/Identity/Digital/Software/Platform.jsonld
+++ b/v1/Vocabulary/Identity/Digital/Software/Platform.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Group.jsonld
+++ b/v1/Vocabulary/Identity/Group.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Group/LegalEntity.jsonld
+++ b/v1/Vocabulary/Identity/Group/LegalEntity.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Group/LegalEntity/ListedCompany.jsonld
+++ b/v1/Vocabulary/Identity/Group/LegalEntity/ListedCompany.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Group/LegalEntity/NonListedCompany.jsonld
+++ b/v1/Vocabulary/Identity/Group/LegalEntity/NonListedCompany.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Group/LegalEntity/NonListedCompany/HousingCompany.jsonld
+++ b/v1/Vocabulary/Identity/Group/LegalEntity/NonListedCompany/HousingCompany.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Group/NonLegalEntity.jsonld
+++ b/v1/Vocabulary/Identity/Group/NonLegalEntity.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Person.jsonld
+++ b/v1/Vocabulary/Identity/Person.jsonld
@@ -39,96 +39,19 @@
             ]
         }
     },
-    "updatedBy": {
-        "@id": "pot:updatedBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
-        },
-        "rdfs:comment": {
-            "en-us": "Updater of an identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "data": {
-        "@id": "pot:data",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Data"
-        },
-        "rdfs:comment": {
-            "en-us": "Data container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
     "createdBy": {
         "@id": "pot:createdBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
         },
         "rdfs:comment": {
             "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",
@@ -153,6 +76,65 @@
             "pot:Link"
         ]
     },
+    "updatedBy": {
+        "@id": "pot:updatedBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
+        },
+        "rdfs:comment": {
+            "en-us": "Updater of an identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
     "lastName": {
         "@id": "pot:lastName",
         "@type": "owl:DatatypeProperty",
@@ -169,6 +151,24 @@
         ],
         "domain": [
             "pot:Person"
+        ]
+    },
+    "data": {
+        "@id": "pot:data",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Data"
+        },
+        "rdfs:comment": {
+            "en-us": "Data container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
         ]
     },
     "firstName": {

--- a/v1/Vocabulary/Identity/Thing.jsonld
+++ b/v1/Vocabulary/Identity/Thing.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Thing/HumanWorld.jsonld
+++ b/v1/Vocabulary/Identity/Thing/HumanWorld.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Thing/HumanWorld/Product.jsonld
+++ b/v1/Vocabulary/Identity/Thing/HumanWorld/Product.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Thing/HumanWorld/Product/DataProduct.jsonld
+++ b/v1/Vocabulary/Identity/Thing/HumanWorld/Product/DataProduct.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Thing/HumanWorld/System.jsonld
+++ b/v1/Vocabulary/Identity/Thing/HumanWorld/System.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment.jsonld
+++ b/v1/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment/Building.jsonld
+++ b/v1/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment/Building.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment/Infrastructure.jsonld
+++ b/v1/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment/Infrastructure.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment/Structure.jsonld
+++ b/v1/Vocabulary/Identity/Thing/HumanWorld/System/BuiltEnvironment/Structure.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Thing/NaturalWorld.jsonld
+++ b/v1/Vocabulary/Identity/Thing/NaturalWorld.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Thing/NaturalWorld/Land.jsonld
+++ b/v1/Vocabulary/Identity/Thing/NaturalWorld/Land.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Thing/NaturalWorld/Water.jsonld
+++ b/v1/Vocabulary/Identity/Thing/NaturalWorld/Water.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual.jsonld
+++ b/v1/Vocabulary/Identity/Virtual.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual/Asset.jsonld
+++ b/v1/Vocabulary/Identity/Virtual/Asset.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual/Collection.jsonld
+++ b/v1/Vocabulary/Identity/Virtual/Collection.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual/Collection/Vocabulary.jsonld
+++ b/v1/Vocabulary/Identity/Virtual/Collection/Vocabulary.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual/Contract.jsonld
+++ b/v1/Vocabulary/Identity/Virtual/Contract.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual/Document.jsonld
+++ b/v1/Vocabulary/Identity/Virtual/Document.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual/Event.jsonld
+++ b/v1/Vocabulary/Identity/Virtual/Event.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual/Event/Task.jsonld
+++ b/v1/Vocabulary/Identity/Virtual/Event/Task.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual/Liability.jsonld
+++ b/v1/Vocabulary/Identity/Virtual/Liability.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual/Process.jsonld
+++ b/v1/Vocabulary/Identity/Virtual/Process.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual/Process/Project.jsonld
+++ b/v1/Vocabulary/Identity/Virtual/Process/Project.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual/Process/Transaction.jsonld
+++ b/v1/Vocabulary/Identity/Virtual/Process/Transaction.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Virtual/Restriction.jsonld
+++ b/v1/Vocabulary/Identity/Virtual/Restriction.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Wilowlfe.jsonld
+++ b/v1/Vocabulary/Identity/Wilowlfe.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Wilowlfe/Fauna.jsonld
+++ b/v1/Vocabulary/Identity/Wilowlfe/Fauna.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Identity/Wilowlfe/Flora.jsonld
+++ b/v1/Vocabulary/Identity/Wilowlfe/Flora.jsonld
@@ -39,13 +39,90 @@
             ]
         }
     },
+    "createdBy": {
+        "@id": "pot:createdBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
+        },
+        "rdfs:comment": {
+            "en-us": "Creator of and identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "metadata": {
+        "@id": "pot:metadata",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Metadata"
+        },
+        "rdfs:comment": {
+            "en-us": "Metadata container"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "name": {
+        "@id": "pot:name",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Nimi",
+            "en-us": "Name"
+        },
+        "rdfs:comment": {
+            "en-us": "Name of the data product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
+        ]
+    },
+    "createdAt": {
+        "@id": "pot:createdAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is created"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
     "updatedBy": {
         "@id": "pot:updatedBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "
@@ -70,83 +147,6 @@
         },
         "pot:valueType": [
             "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "name": {
-        "@id": "pot:name",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
-            "en-us": "Name"
-        },
-        "rdfs:comment": {
-            "en-us": "Name given to the Identity"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App",
-            "pot:DataProduct",
-            "pot:Identity",
-            "pot:Person"
-        ]
-    },
-    "metadata": {
-        "@id": "pot:metadata",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Metadata"
-        },
-        "rdfs:comment": {
-            "en-us": "Metadata container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "createdAt": {
-        "@id": "pot:createdAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is created"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Link.jsonld
+++ b/v1/Vocabulary/Link.jsonld
@@ -39,16 +39,16 @@
             ]
         }
     },
-    "updatedBy": {
-        "@id": "pot:updatedBy",
+    "createdBy": {
+        "@id": "pot:createdBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
         },
         "rdfs:comment": {
-            "en-us": "Updater of an identity "
+            "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
@@ -67,43 +67,6 @@
         },
         "rdfs:comment": {
             "en-us": "Data container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "updatedAt": {
-        "@id": "pot:updatedAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Päivitysaika",
-            "en-us": "Update time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is updated"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
-        ],
-        "domain": [
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
@@ -136,8 +99,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
         },
         "rdfs:comment": {
             "en-us": "Time when the data is created"
@@ -147,6 +110,43 @@
         ],
         "domain": [
             "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedBy": {
+        "@id": "pot:updatedBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
+        },
+        "rdfs:comment": {
+            "en-us": "Updater of an identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedAt": {
+        "@id": "pot:updatedAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Päivitysaika",
+            "en-us": "Update time"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is updated"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
             "pot:Link"
         ]
     },

--- a/v1/Vocabulary/Link/AtDataProduct.jsonld
+++ b/v1/Vocabulary/Link/AtDataProduct.jsonld
@@ -39,43 +39,6 @@
             ]
         }
     },
-    "updatedBy": {
-        "@id": "pot:updatedBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
-        },
-        "rdfs:comment": {
-            "en-us": "Updater of an identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "data": {
-        "@id": "pot:data",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Data"
-        },
-        "rdfs:comment": {
-            "en-us": "Data container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
     "updatedAt": {
         "@id": "pot:updatedAt",
         "@type": "owl:DatatypeProperty",
@@ -99,8 +62,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
         },
         "rdfs:comment": {
             "en-us": "Creator of and identity "
@@ -136,14 +99,51 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
         },
         "rdfs:comment": {
             "en-us": "Time when the data is created"
         },
         "pot:valueType": [
             "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedBy": {
+        "@id": "pot:updatedBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
+        },
+        "rdfs:comment": {
+            "en-us": "Updater of an identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "data": {
+        "@id": "pot:data",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Data"
+        },
+        "rdfs:comment": {
+            "en-us": "Data container"
+        },
+        "pot:valueType": [
+            "xsd:string"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Link/PublishedOn.jsonld
+++ b/v1/Vocabulary/Link/PublishedOn.jsonld
@@ -39,61 +39,6 @@
             ]
         }
     },
-    "productCode": {
-        "@id": "pot:productCode",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Product code",
-            "fi-fi": "Tuotekoodi"
-        },
-        "rdfs:comment": {
-            "en-us": "Unique identifier of a product"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:PublishedOn"
-        ]
-    },
-    "updatedBy": {
-        "@id": "pot:updatedBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
-        },
-        "rdfs:comment": {
-            "en-us": "Updater of an identity "
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "data": {
-        "@id": "pot:data",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Data"
-        },
-        "rdfs:comment": {
-            "en-us": "Data container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
     "updatedAt": {
         "@id": "pot:updatedAt",
         "@type": "owl:DatatypeProperty",
@@ -117,8 +62,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
         },
         "rdfs:comment": {
             "en-us": "Creator of and identity "
@@ -129,6 +74,24 @@
         "domain": [
             "pot:Identity",
             "pot:Link"
+        ]
+    },
+    "productCode": {
+        "@id": "pot:productCode",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Product code",
+            "fi-fi": "Tuotekoodi"
+        },
+        "rdfs:comment": {
+            "en-us": "Unique identifier of a product"
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:PublishedOn"
         ]
     },
     "metadata": {
@@ -154,14 +117,51 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
         },
         "rdfs:comment": {
             "en-us": "Time when the data is created"
         },
         "pot:valueType": [
             "xsd:dateTime"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedBy": {
+        "@id": "pot:updatedBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
+        },
+        "rdfs:comment": {
+            "en-us": "Updater of an identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "data": {
+        "@id": "pot:data",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "en-us": "Data"
+        },
+        "rdfs:comment": {
+            "en-us": "Data container"
+        },
+        "pot:valueType": [
+            "xsd:string"
         ],
         "domain": [
             "pot:Identity",

--- a/v1/Vocabulary/Link/Role.jsonld
+++ b/v1/Vocabulary/Link/Role.jsonld
@@ -39,16 +39,16 @@
             ]
         }
     },
-    "updatedBy": {
-        "@id": "pot:updatedBy",
+    "createdBy": {
+        "@id": "pot:createdBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
         },
         "rdfs:comment": {
-            "en-us": "Updater of an identity "
+            "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
@@ -67,43 +67,6 @@
         },
         "rdfs:comment": {
             "en-us": "Data container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "updatedAt": {
-        "@id": "pot:updatedAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Päivitysaika",
-            "en-us": "Update time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is updated"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
-        ],
-        "domain": [
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
@@ -136,8 +99,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
         },
         "rdfs:comment": {
             "en-us": "Time when the data is created"
@@ -147,6 +110,43 @@
         ],
         "domain": [
             "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedBy": {
+        "@id": "pot:updatedBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
+        },
+        "rdfs:comment": {
+            "en-us": "Updater of an identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedAt": {
+        "@id": "pot:updatedAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Päivitysaika",
+            "en-us": "Update time"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is updated"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
             "pot:Link"
         ]
     },

--- a/v1/Vocabulary/Link/Role/DeveloperAt.jsonld
+++ b/v1/Vocabulary/Link/Role/DeveloperAt.jsonld
@@ -39,16 +39,16 @@
             ]
         }
     },
-    "updatedBy": {
-        "@id": "pot:updatedBy",
+    "createdBy": {
+        "@id": "pot:createdBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
         },
         "rdfs:comment": {
-            "en-us": "Updater of an identity "
+            "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
@@ -67,43 +67,6 @@
         },
         "rdfs:comment": {
             "en-us": "Data container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "updatedAt": {
-        "@id": "pot:updatedAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Päivitysaika",
-            "en-us": "Update time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is updated"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
-        ],
-        "domain": [
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
@@ -136,8 +99,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
         },
         "rdfs:comment": {
             "en-us": "Time when the data is created"
@@ -147,6 +110,43 @@
         ],
         "domain": [
             "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedBy": {
+        "@id": "pot:updatedBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
+        },
+        "rdfs:comment": {
+            "en-us": "Updater of an identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedAt": {
+        "@id": "pot:updatedAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Päivitysaika",
+            "en-us": "Update time"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is updated"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
             "pot:Link"
         ]
     },

--- a/v1/Vocabulary/Link/Role/DeveloperOf.jsonld
+++ b/v1/Vocabulary/Link/Role/DeveloperOf.jsonld
@@ -39,16 +39,16 @@
             ]
         }
     },
-    "updatedBy": {
-        "@id": "pot:updatedBy",
+    "createdBy": {
+        "@id": "pot:createdBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
         },
         "rdfs:comment": {
-            "en-us": "Updater of an identity "
+            "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
@@ -67,43 +67,6 @@
         },
         "rdfs:comment": {
             "en-us": "Data container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "updatedAt": {
-        "@id": "pot:updatedAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Päivitysaika",
-            "en-us": "Update time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is updated"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
-        ],
-        "domain": [
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
@@ -136,8 +99,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
         },
         "rdfs:comment": {
             "en-us": "Time when the data is created"
@@ -147,6 +110,43 @@
         ],
         "domain": [
             "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedBy": {
+        "@id": "pot:updatedBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
+        },
+        "rdfs:comment": {
+            "en-us": "Updater of an identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedAt": {
+        "@id": "pot:updatedAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Päivitysaika",
+            "en-us": "Update time"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is updated"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
             "pot:Link"
         ]
     },

--- a/v1/Vocabulary/Link/Role/MemberOf.jsonld
+++ b/v1/Vocabulary/Link/Role/MemberOf.jsonld
@@ -39,16 +39,16 @@
             ]
         }
     },
-    "updatedBy": {
-        "@id": "pot:updatedBy",
+    "createdBy": {
+        "@id": "pot:createdBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
         },
         "rdfs:comment": {
-            "en-us": "Updater of an identity "
+            "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
@@ -67,43 +67,6 @@
         },
         "rdfs:comment": {
             "en-us": "Data container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "updatedAt": {
-        "@id": "pot:updatedAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Päivitysaika",
-            "en-us": "Update time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is updated"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
-        ],
-        "domain": [
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
@@ -136,8 +99,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
         },
         "rdfs:comment": {
             "en-us": "Time when the data is created"
@@ -147,6 +110,43 @@
         ],
         "domain": [
             "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedBy": {
+        "@id": "pot:updatedBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
+        },
+        "rdfs:comment": {
+            "en-us": "Updater of an identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedAt": {
+        "@id": "pot:updatedAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Päivitysaika",
+            "en-us": "Update time"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is updated"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
             "pot:Link"
         ]
     },

--- a/v1/Vocabulary/Link/Role/UserOf.jsonld
+++ b/v1/Vocabulary/Link/Role/UserOf.jsonld
@@ -39,16 +39,16 @@
             ]
         }
     },
-    "updatedBy": {
-        "@id": "pot:updatedBy",
+    "createdBy": {
+        "@id": "pot:createdBy",
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
         },
         "rdfs:comment": {
-            "en-us": "Updater of an identity "
+            "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
@@ -67,43 +67,6 @@
         },
         "rdfs:comment": {
             "en-us": "Data container"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:Identity",
-            "pot:Link"
-        ]
-    },
-    "updatedAt": {
-        "@id": "pot:updatedAt",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Päivitysaika",
-            "en-us": "Update time"
-        },
-        "rdfs:comment": {
-            "en-us": "Time when the data is updated"
-        },
-        "pot:valueType": [
-            "xsd:dateTime"
-        ],
-        "domain": [
-            "pot:Link"
-        ]
-    },
-    "createdBy": {
-        "@id": "pot:createdBy",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
-        },
-        "rdfs:comment": {
-            "en-us": "Creator of and identity "
         },
         "pot:valueType": [
             "xsd:string"
@@ -136,8 +99,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
         },
         "rdfs:comment": {
             "en-us": "Time when the data is created"
@@ -147,6 +110,43 @@
         ],
         "domain": [
             "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedBy": {
+        "@id": "pot:updatedBy",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
+        },
+        "rdfs:comment": {
+            "en-us": "Updater of an identity "
+        },
+        "pot:valueType": [
+            "xsd:string"
+        ],
+        "domain": [
+            "pot:Identity",
+            "pot:Link"
+        ]
+    },
+    "updatedAt": {
+        "@id": "pot:updatedAt",
+        "@type": "owl:DatatypeProperty",
+        "subPropertyOf": "pot:topDataProperty",
+        "rdfs:label": {
+            "fi-fi": "Päivitysaika",
+            "en-us": "Update time"
+        },
+        "rdfs:comment": {
+            "en-us": "Time when the data is updated"
+        },
+        "pot:valueType": [
+            "xsd:dateTime"
+        ],
+        "domain": [
             "pot:Link"
         ]
     },

--- a/v1/Vocabulary/createdAt.jsonld
+++ b/v1/Vocabulary/createdAt.jsonld
@@ -44,8 +44,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Luomisaika",
-            "en-us": "Creation time"
+            "en-us": "Creation time",
+            "fi-fi": "Luomisaika"
         },
         "rdfs:comment": {
             "en-us": "Time when the data is created"

--- a/v1/Vocabulary/createdBy.jsonld
+++ b/v1/Vocabulary/createdBy.jsonld
@@ -44,8 +44,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Identiteetin luoja",
-            "en-us": "Creator"
+            "en-us": "Creator",
+            "fi-fi": "Identiteetin luoja"
         },
         "rdfs:comment": {
             "en-us": "Creator of and identity "

--- a/v1/Vocabulary/name.jsonld
+++ b/v1/Vocabulary/name.jsonld
@@ -44,20 +44,20 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Identiteetin nimi",
+            "fi-fi": "Nimi",
             "en-us": "Name"
         },
         "rdfs:comment": {
-            "en-us": "Name given to the Identity"
+            "en-us": "Name of the data product"
         },
         "pot:valueType": [
             "xsd:string"
         ],
         "domain": [
-            "pot:App",
-            "pot:DataProduct",
             "pot:Identity",
-            "pot:Person"
+            "pot:Person",
+            "pot:App",
+            "pot:DataProduct"
         ]
     }
 }

--- a/v1/Vocabulary/nest.jsonld
+++ b/v1/Vocabulary/nest.jsonld
@@ -39,22 +39,8 @@
             ]
         }
     },
-    "privacyPolicyUrl": {
-        "@id": "pot:privacyPolicyUrl",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "rdfs:label": {
-            "en-us": "Privacy policy URL",
-            "fi-fi": "Tietousojaselosteen URL"
-        },
-        "rdfs:comment": {
-            "en-us": "Privacy policy URL of an app"
-        },
-        "pot:valueType": [
-            "xsd:string"
-        ],
-        "domain": [
-            "pot:App"
-        ]
+    "nest": {
+        "@id": "pot:nest",
+        "@type": "owl:AnnotationProperty"
     }
 }

--- a/v1/Vocabulary/readonly.jsonld
+++ b/v1/Vocabulary/readonly.jsonld
@@ -41,10 +41,6 @@
     },
     "readonly": {
         "@id": "pot:readonly",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "pot:valueType": [
-            "xsd:boolean"
-        ]
+        "@type": "owl:AnnotationProperty"
     }
 }

--- a/v1/Vocabulary/required.jsonld
+++ b/v1/Vocabulary/required.jsonld
@@ -41,10 +41,6 @@
     },
     "required": {
         "@id": "pot:required",
-        "@type": "owl:DatatypeProperty",
-        "subPropertyOf": "pot:topDataProperty",
-        "pot:valueType": [
-            "xsd:boolean"
-        ]
+        "@type": "owl:AnnotationProperty"
     }
 }

--- a/v1/Vocabulary/updatedBy.jsonld
+++ b/v1/Vocabulary/updatedBy.jsonld
@@ -44,8 +44,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "en-us": "Updater",
-            "fi-fi": "Identieetin päivittäjä"
+            "fi-fi": "Identieetin päivittäjä",
+            "en-us": "Updater"
         },
         "rdfs:comment": {
             "en-us": "Updater of an identity "

--- a/v1/Vocabulary/webpageUrl.jsonld
+++ b/v1/Vocabulary/webpageUrl.jsonld
@@ -44,8 +44,8 @@
         "@type": "owl:DatatypeProperty",
         "subPropertyOf": "pot:topDataProperty",
         "rdfs:label": {
-            "fi-fi": "Websivun URL",
-            "en-us": "Webpage URL"
+            "en-us": "Webpage URL",
+            "fi-fi": "Websivun URL"
         },
         "rdfs:comment": {
             "en-us": "Webpage URL of an app"


### PR DESCRIPTION
Changed `<nest rdf:resource="https://standards.oftrust.net/v1/Vocabulary/data"/>` to `<nest rdf:resource="https://standards.lifeengine.io/v1/Vocabulary/data"/>`

Generated Vocabulary, Context, ClassDefinitions according to updated `dli.owl`